### PR TITLE
Add an edit version number to the header

### DIFF
--- a/mysql/my-5.1-rhel.cnf
+++ b/mysql/my-5.1-rhel.cnf
@@ -1,5 +1,5 @@
 ##  _______________________________________________________________________
-## / Rackspace MySQL 5.1 Configuration File v2.13                          \
+## / Rackspace MySQL 5.1 Configuration File                                \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |
@@ -10,7 +10,9 @@
 ## | While the settings provided are likely sufficient for most            |
 ## | situations, an exhaustive list of settings (with descriptions) can be |
 ## | found at:                                                             |
-## \ http://dev.mysql.com/doc/refman/5.1/en/server-system-variables.html   /
+## | http://dev.mysql.com/doc/refman/5.1/en/server-system-variables.html   |
+## |                                                                       |
+## \ Based on v3.0.0    https://github.com/rackerlabs/rs-db-config         /
 ##  -----------------------------------------------------------------------
 ##         \   ^__^
 ##          \  (oo)\_______

--- a/mysql/my-5.1-rhel.cnf
+++ b/mysql/my-5.1-rhel.cnf
@@ -1,5 +1,5 @@
-##  _______________________________________________________________________ 
-## / Rackspace MySQL 5.1 Configuration File v2.12                          \
+##  _______________________________________________________________________
+## / Rackspace MySQL 5.1 Configuration File v2.13                          \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |
@@ -11,7 +11,7 @@
 ## | situations, an exhaustive list of settings (with descriptions) can be |
 ## | found at:                                                             |
 ## \ http://dev.mysql.com/doc/refman/5.1/en/server-system-variables.html   /
-##  ----------------------------------------------------------------------- 
+##  -----------------------------------------------------------------------
 ##         \   ^__^
 ##          \  (oo)\_______
 ##             (__)\       )\/\
@@ -34,7 +34,7 @@ open-files-limit                = 20000
 thread-cache-size               = 16
 table-open-cache                = 2048
 table-definition-cache          = 512
-query-cache-size                = 32M 
+query-cache-size                = 32M
 query-cache-limit               = 1M
 
 ## Per-thread Buffers
@@ -44,8 +44,8 @@ read-rnd-buffer-size            = 8M
 join-buffer-size                = 1M
 
 ## Temp Tables
-tmp-table-size                  = 64M 
-max-heap-table-size             = 64M 
+tmp-table-size                  = 64M
+max-heap-table-size             = 64M
 
 ## Networking
 back-log                        = 100
@@ -60,7 +60,7 @@ wait-timeout                    = 600
 innodb                          = FORCE
 
 ## MyISAM
-key-buffer-size                 = 64M 
+key-buffer-size                 = 64M
 myisam-sort-buffer-size         = 128M
 
 ## InnoDB

--- a/mysql/my-5.5-rhel.cnf
+++ b/mysql/my-5.5-rhel.cnf
@@ -1,5 +1,5 @@
-##  _______________________________________________________________________ 
-## / Rackspace MySQL 5.5 Configuration File                                \
+##  _______________________________________________________________________
+## / Rackspace MySQL 5.5 Configuration File v1.00                          \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |
@@ -11,7 +11,7 @@
 ## | situations, an exhaustive list of settings (with descriptions) can be |
 ## | found at:                                                             |
 ## \ http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html   /
-##  ----------------------------------------------------------------------- 
+##  -----------------------------------------------------------------------
 ##         \   ^__^
 ##          \  (oo)\_______
 ##             (__)\       )\/\
@@ -32,7 +32,7 @@ sql-mode                        = NO_ENGINE_SUBSTITUTION
 thread-cache-size               = 16
 table-open-cache                = 4096
 table-definition-cache          = 2048
-query-cache-size                = 32M 
+query-cache-size                = 32M
 query-cache-limit               = 1M
 
 ## Per-thread Buffers
@@ -42,8 +42,8 @@ read-rnd-buffer-size            = 1M
 join-buffer-size                = 1M
 
 ## Temp Tables
-tmp-table-size                  = 32M 
-max-heap-table-size             = 64M 
+tmp-table-size                  = 32M
+max-heap-table-size             = 64M
 
 ## Networking
 back-log                        = 100
@@ -58,7 +58,7 @@ wait-timeout                    = 600
 innodb                          = FORCE
 
 ## MyISAM
-key-buffer-size                 = 64M 
+key-buffer-size                 = 64M
 myisam-sort-buffer-size         = 128M
 
 ## InnoDB

--- a/mysql/my-5.5-rhel.cnf
+++ b/mysql/my-5.5-rhel.cnf
@@ -1,5 +1,5 @@
 ##  _______________________________________________________________________
-## / Rackspace MySQL 5.5 Configuration File v1.00                          \
+## / Rackspace MySQL 5.5 Configuration File                                \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |
@@ -10,7 +10,9 @@
 ## | While the settings provided are likely sufficient for most            |
 ## | situations, an exhaustive list of settings (with descriptions) can be |
 ## | found at:                                                             |
-## \ http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html   /
+## | http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html   |
+## |                                                                       |
+## \ Based on v3.0.0    https://github.com/rackerlabs/rs-db-config         /
 ##  -----------------------------------------------------------------------
 ##         \   ^__^
 ##          \  (oo)\_______

--- a/mysql/my-5.5-ubuntu.cnf
+++ b/mysql/my-5.5-ubuntu.cnf
@@ -1,5 +1,5 @@
 ##  _______________________________________________________________________
-## / Rackspace MySQL 5.5 Configuration File v1.00                          \
+## / Rackspace MySQL 5.5 Configuration File                                \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |
@@ -10,7 +10,9 @@
 ## | While the settings provided are likely sufficient for most            |
 ## | situations, an exhaustive list of settings (with descriptions) can be |
 ## | found at:                                                             |
-## \ http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html   /
+## | http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html   |
+## |                                                                       |
+## \ Based on v3.0.0    https://github.com/rackerlabs/rs-db-config         /
 ##  -----------------------------------------------------------------------
 ##         \   ^__^
 ##          \  (oo)\_______

--- a/mysql/my-5.5-ubuntu.cnf
+++ b/mysql/my-5.5-ubuntu.cnf
@@ -1,3 +1,23 @@
+##  _______________________________________________________________________
+## / Rackspace MySQL 5.5 Configuration File v1.00                          \
+## |                                                                       |
+## | This is a base configuration file containing the most frequently used |
+## | settings with reasonably defined default values for configuring and   |
+## | tuning MySQL. Note that these settings can likely be further tuned in |
+## | order to get optimum performance from MySQL based upon the database   |
+## | configuration and hardware platform.                                  |
+## |                                                                       |
+## | While the settings provided are likely sufficient for most            |
+## | situations, an exhaustive list of settings (with descriptions) can be |
+## | found at:                                                             |
+## \ http://dev.mysql.com/doc/refman/5.5/en/server-system-variables.html   /
+##  -----------------------------------------------------------------------
+##         \   ^__^
+##          \  (oo)\_______
+##             (__)\       )\/\
+##                 ||----w |
+##                 ||     ||
+
 [mysqld]
 ## General
 datadir                         = /var/lib/mysql

--- a/mysql/my-5.6-rhel.cnf
+++ b/mysql/my-5.6-rhel.cnf
@@ -1,5 +1,5 @@
 ##  _______________________________________________________________________
-## / Rackspace MySQL 5.6 Configuration File                                \
+## / Rackspace MySQL 5.6 Configuration File v1.00                          \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |

--- a/mysql/my-5.6-rhel.cnf
+++ b/mysql/my-5.6-rhel.cnf
@@ -1,5 +1,5 @@
 ##  _______________________________________________________________________
-## / Rackspace MySQL 5.6 Configuration File v1.00                          \
+## / Rackspace MySQL 5.6 Configuration File                                \
 ## |                                                                       |
 ## | This is a base configuration file containing the most frequently used |
 ## | settings with reasonably defined default values for configuring and   |
@@ -10,7 +10,9 @@
 ## | For many deployments, the only variables which need to be modified    |
 ## | below are max-connections and innodb-buffer-pool-size.                |
 ## |                                                                       |
-## \ http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html   /
+## | http://dev.mysql.com/doc/refman/5.6/en/server-system-variables.html   |
+## |                                                                       |
+## \ Based on v3.0.0    https://github.com/rackerlabs/rs-db-config         /
 ##  -----------------------------------------------------------------------
 ##         \   ^__^
 ##          \  (oo)\_______


### PR DESCRIPTION
- Add a version number to the file contents to track an edit version.

- If a file is copied instead of cloned then the version control
  information is lost after the copy. The edit version is not.

- While the edit version **may** not match the version control version they
  **should** match. Updating an option in the configuration **must**
  update the edit version. Updating spacing, comments, or anything that
  does not alter how the database operates **should** update the edit version.
  In other words, every commit **may** not need a version bump unless the
  change alters the running configuration.